### PR TITLE
Replace taskData by inputData in core API

### DIFF
--- a/lib/application/execute.js
+++ b/lib/application/execute.js
@@ -4,7 +4,7 @@ module.exports = (api, { serviceID, taskKey, inputs }) => ({ eventKey, eventData
   .ExecuteTask({
     serviceID,
     taskKey,
-    taskData: JSON.stringify(typeof inputs === 'function'
+    inputData: JSON.stringify(typeof inputs === 'function'
       ? inputs(eventKey, JSON.parse(eventData))
       : inputs || {}),
   }, apiResponse(resolve, reject)))

--- a/proto/api-core.proto
+++ b/proto/api-core.proto
@@ -25,7 +25,7 @@ message ListenEventRequest {
 message ExecuteTaskRequest {
   string serviceID = 1;
   string taskKey = 2;
-  string taskData = 3;
+  string inputData = 3;
 }
 
 message ListenResultRequest {


### PR DESCRIPTION
Replace `taskData` by `inputData` in `core` API.

Related to https://github.com/mesg-foundation/core/issues/229.
Close #4.