### PR TITLE
flexible application & service init

### DIFF
--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -3,21 +3,15 @@ import { createClient } from '../util/grpc'
 
 const defaultEndpoint = process.env.MESG_ENDPOINT
 
-var defaultApplication: Application
-
 type Options = {
   endpoint?: string
 }
 
 const applicationBuilder = (options?: Options) => {
-	if (!defaultApplication){
-		const endpoint = options && options.endpoint ? options.endpoint: defaultEndpoint;
-		defaultApplication = new Application({
-			client: createClient('Core', 'api-core.proto', endpoint)
-		});
-	}
-
-	return defaultApplication;
+	const endpoint = options && options.endpoint ? options.endpoint: defaultEndpoint;
+	return new Application({
+		client: createClient('Core', 'api-core.proto', endpoint)
+	});
 }
 
 export default applicationBuilder;

--- a/src/application/index.ts
+++ b/src/application/index.ts
@@ -7,7 +7,7 @@ type Options = {
   endpoint?: string
 }
 
-const applicationBuilder = (options?: Options) => {
+const applicationBuilder = (options?: Options): Application => {
 	const endpoint = options && options.endpoint ? options.endpoint: defaultEndpoint;
 	return new Application({
 		client: createClient('Core', 'api-core.proto', endpoint)

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -7,20 +7,13 @@ const token = process.env.MESG_TOKEN
 const endpoint = process.env.MESG_ENDPOINT
 const ymlPath = './mesg.yml'
 
-var defaultService: Service
-
 const serviceBuilder = () => {
-	if (!defaultService) {
-		const mesgConfig = YAML.safeLoad(fs.readFileSync(ymlPath));
-
-		defaultService = new Service({
-			token: token,
-			mesgConfig: mesgConfig,
-			client: createClient('Service', 'api-service.proto', endpoint)
-		});
-	}
-
-	return defaultService;
+	const mesgConfig = YAML.safeLoad(fs.readFileSync(ymlPath));
+	return new Service({
+		token: token,
+		mesgConfig: mesgConfig,
+		client: createClient('Service', 'api-service.proto', endpoint)
+	});
 }
 
 export default serviceBuilder;

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -7,7 +7,7 @@ const token = process.env.MESG_TOKEN
 const endpoint = process.env.MESG_ENDPOINT
 const ymlPath = './mesg.yml'
 
-const serviceBuilder = () => {
+const serviceBuilder = (): Service => {
 	const mesgConfig = YAML.safeLoad(fs.readFileSync(ymlPath));
 	return new Service({
 		token: token,


### PR DESCRIPTION
Currently there is no way to init application multiple times by using the _mesg-js_ pkg unless accessing to _mesg-js/application/application_ in the import path directly.

But we shouldn't have this limitation for application because devs may need to create multiple applications for different endpoints in the same program. And there is no reason to handle this _defaultApplication_ logic behavior inside this pkg. Devs can implement their own if they need to.

I applied the same thing for service part as well, for convenience.