### PR TITLE
Single Output simplification

### DIFF
--- a/src/protobuf/coreapi/api.proto
+++ b/src/protobuf/coreapi/api.proto
@@ -85,14 +85,12 @@ message EventData {
 // {
 //   "serviceID":     "__SERVICE_ID__",
 //   "taskFilter":    "__TASK_KEY_TO_MATCH__",
-//   "outputFilter":  "__OUTPUT_KEY_TO_MATCH__",
 //   "tagFilters":     ["tagX"]
 // }
 // ```
 message ListenResultRequest {
   string serviceID = 1;           // The Service ID. Generated when using the [`DeployService` API](#deployservice).
   string taskFilter = 2;          // __Optional.__  The task's key to filter. The task must match this key. The default is `*` which matches any task.
-  string outputFilter = 3;        // __Optional.__ The output's key from the task to filter. The task must return this output's key. The default is `*` which matches any output.
   repeated string tagFilters = 4; // __Optional.__ The list of tags to filter. This is a "match all" list. All tags in parameters should be included in the execution to match.
 }
 
@@ -104,7 +102,6 @@ message ListenResultRequest {
 // {
 //   "executionID":   "__EXECUTION_ID__",
 //   "taskKey":       "__TASK_KEY__",
-//   "outputKey":     "__OUTPUT_KEY__",
 //   "outputData":    "{\"foo\":\"bar\"}",
 //   "executionTags": ["executionX", "test"],
 //   "error":         "error from the execution if something went wrong",
@@ -113,7 +110,6 @@ message ListenResultRequest {
 message ResultData {
   string executionID = 1;             // The unique identifier of the execution.
   string taskKey = 2;                 // The key of the executed task.
-  string outputKey = 3;               // The output's key from the returned task.
   string outputData = 4;              // The output's data from the returned task, encoded in JSON.
   repeated string executionTags = 5;  // The list of tags associated with the execution.
   string error = 6;                   // The execution's error if something went wrong.

--- a/src/protobuf/definition/service.proto
+++ b/src/protobuf/definition/service.proto
@@ -30,15 +30,7 @@ message Task {
   string name = 1;                    // Task's name.
   string description = 2;             // Task's description.
   repeated Parameter inputs = 6;      // List inputs of this task.
-  repeated Output outputs = 7;        // List of outputs this task can return.
-}
-
-// Output is the data a task returns.
-message Output {
-  string key = 4;                   // Output's key.
-  string name = 1;                  // Output's name.
-  string description = 2;           // Output's description.
-  repeated Parameter data = 3;      // List of data of this output.
+  repeated Parameter outputs = 7;     // List of tasks outputs.
 }
 
 // Parameter describes the task's inputs, the task's outputs, and the event's data.

--- a/src/protobuf/serviceapi/api.proto
+++ b/src/protobuf/serviceapi/api.proto
@@ -83,14 +83,16 @@ message TaskData {
 // ```json
 // {
 //   "executionID": "__EXECUTION_ID__",
-//   "outputKey":   "__OUTPUT_KEY__",
 //   "outputData":  "{\"foo\":\"super result\",\"bar\":true}"
+//   "error":  "{\"message\":\"some error\"}"
 // }
 // ```
 message SubmitResultRequest {
   string executionID = 1; // The `executionID` received from the [`ListenTask` stream](#listentask).
-  string outputKey = 2;   // The output's key as defined in the [service file](../guide/service/service-file.md).
-  string outputData = 3;  // The result's data encoded in JSON as defined in the [service file](../guide/service/service-file.md).
+  oneof result {
+    string outputData = 3;  // The result's data encoded in JSON as defined in the [service file](../guide/service/service-file.md).
+    string error = 4;       // The error message.
+  }
 }
 
 // Reply of `SubmitResult` API doesn't contain any data.

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -26,7 +26,6 @@ export {
   Tasks,
   TaskInputs,
   TaskOutputs,
-  TaskOutputCallbackInput,
   Stream,
   EmitEventReply,
   SubmitResultReply,

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -3,9 +3,9 @@ import { Stream } from '../util/grpc';
 
 
 type Options = {
-    token: string
-    definition: any
-    client
+  token: string
+  definition: any
+  client
 }
 
 class Service {
@@ -33,9 +33,9 @@ class Service {
     return stream;
   }
 
-  emitEvent(event: string, data: EventData): Promise<EmitEventReply | Error> {
+  emitEvent(event: string, data: EventData): Promise<EmitEventReply> {
     if (!data) throw new Error('data object must be send while emitting event')
-    return new Promise<EmitEventReply | Error>((resolve, reject) => {
+    return new Promise<EmitEventReply>((resolve, reject) => {
       this.api.emitEvent({
         token: this.token,
         eventKey: event,
@@ -44,30 +44,26 @@ class Service {
     })
   }
 
-  private handleTaskData({ executionID, taskKey, inputData }) {
+  private async handleTaskData({ executionID, taskKey, inputData }) {
     const callback = this.tasks[taskKey];
     if (!callback) {
       throw new Error(`Task ${taskKey} is not defined in your services`);
     }
-
     const data = JSON.parse(inputData);
-    const outputs = {};
-    const taskConfig = this.definition.tasks[taskKey];
-
-    for (let outputKey in taskConfig.outputs){
-      outputs[outputKey] = (data: TaskOutputCallbackInput): Promise<SubmitResultReply | Error> => {
-        if (!data) throw new Error('data object must be send while submitting output')
-        return new Promise<SubmitResultReply | Error>((resolve, reject) => {
-          this.api.submitResult({
-            executionID,
-            outputKey,
-            outputData: JSON.stringify(data)
-          }, handleAPIResponse(resolve, reject));
-        })
-      }
+    try {
+      const outputs = await callback(data);
+      const outputData = JSON.stringify(outputs);
+      return this.submitResult({ executionID, outputData });
+    } catch (err) {
+      const error = err.message;
+      return this.submitResult({ executionID, error });
     }
+  }
 
-    callback(data, outputs);
+  private submitResult(payload: any)  {
+    return new Promise<SubmitResultReply>((resolve, reject) => {
+      this.api.submitResult(payload, handleAPIResponse(resolve, reject));
+    })
   }
 
   private validateTaskNames(){
@@ -83,7 +79,7 @@ class Service {
 }
 
 interface Tasks {
-  [task: string]: (inputs: TaskInputs, outputs: TaskOutputs) => void
+  [task: string]: (inputs: TaskInputs) => TaskOutputs
 }
 
 interface TaskInputs {
@@ -91,10 +87,6 @@ interface TaskInputs {
 }
 
 interface TaskOutputs  {
-  [key: string]: (input: TaskOutputCallbackInput) => Promise<void>
-}
-
-interface TaskOutputCallbackInput {
   [key: string]: any
 }
 
@@ -120,7 +112,6 @@ export {
   Tasks,
   TaskInputs,
   TaskOutputs,
-  TaskOutputCallbackInput,
   Stream,
   EmitEventReply,
   SubmitResultReply,


### PR DESCRIPTION
This PR update the lib to be compatible only with single output!

- Task function just need to return their output. No need to call a output callback
- Task's error can just be thrown. They will be catch by the lib
- No more callback passed to tasks

To test, use the tag `beta`, run the following command:
```
npm install github:mesg-foundation/mesg-js#beta
```