### PR TITLE
Add instance name resolution

### DIFF
--- a/src/application/application.ts
+++ b/src/application/application.ts
@@ -1,6 +1,7 @@
 import * as uuidv4 from 'uuid/v4'
 import { checkStreamReady, errNoStatus, Stream } from '../util/grpc';
 import { API, ExecutionCreateInputs, ExecutionCreateOutputs, EventStreamInputs, Event, ExecutionStreamInputs, Execution, ExecutionStatus } from '../api';
+import { resolveSID } from '../util/resolve';
 
 type Options = {
   client
@@ -12,6 +13,10 @@ class Application {
 
   constructor(api: API) {
     this.api = api;
+  }
+
+  resolve(sid: string): Promise<string> {
+    return resolveSID(this.api, sid)
   }
 
   listenEvent(request: EventStreamInputs): Stream<Event> {

--- a/src/util/resolve.ts
+++ b/src/util/resolve.ts
@@ -10,7 +10,7 @@ export const resolveSID = async (api: API, sid: string): Promise<hash> => {
   const { services } = await api.service.list({})
 
   const matching = services.filter(x => x.sid === sid)
-  if (matching.length == 0) throw new Error(`cannot resolve ${sid}`)
+  if (matching.length === 0) throw new Error(`cannot resolve ${sid}`)
   if (matching.length > 1) throw new Error(`multiple services resolve ${sid}`)
   const service = matching[0]
 

--- a/src/util/resolve.ts
+++ b/src/util/resolve.ts
@@ -1,0 +1,42 @@
+import { hash, API, Instance } from "../api";
+
+const _resolutionTable: Map<string, hash> = new Map()
+
+// findInstanceFromService returns an instance of a service with the following strategy:
+//   - find a service that has the same hash than the serviceID
+//   - find a service that has the same sid than the serviceID (only if there is no match for the hash)
+//   - get all the instances of this service
+//   - return the instance of the service and throw an error if there is other than one instance running
+const findInstanceFromService = async (api: API, serviceID: string): Promise<Instance> => {
+  const { services } = await api.service.list({})
+  // Find by hash then by sid
+  const service = services.find(x => x.hash === serviceID) || services.find(x => x.sid === serviceID)
+  if (!service) throw new Error(`cannot resolve ${serviceID}`)
+
+  // find matching instances
+  const { instances } = await api.instance.list({ serviceHash: service.hash })
+  if (!instances || instances.length === 0) throw new Error(`no instances running for the service ${service.sid}`)
+  if (instances.length > 1) throw new Error(`multiple instances running for the service ${service.sid}`)
+  return instances[0]
+}
+
+// resolveInstanceHash
+// Return the instance hash based on a serviceID that can be:
+//   - instanceHash
+//   - sid
+//   - serviceHash
+// Throw an error if a serviceID has multiple instances running
+// Warning: this function is making multiple requests to the Engine so not really efficient.
+// it needs to be used carefully
+export const resolveInstanceHash = async (api: API, serviceID: string): Promise<hash> => {
+  if (_resolutionTable.has(serviceID)) return _resolutionTable.get(serviceID)
+
+  try {
+    const instance = await api.instance.get({ hash: serviceID })
+    _resolutionTable.set(serviceID, instance.hash)
+  } catch (e) {
+    const instance = await findInstanceFromService(api, serviceID)
+    _resolutionTable.set(serviceID, instance.hash)
+  }
+  return _resolutionTable.get(serviceID)
+}

--- a/src/util/resolve.ts
+++ b/src/util/resolve.ts
@@ -8,8 +8,11 @@ export const resolveSID = async (api: API, sid: string): Promise<hash> => {
   if (_resolutionTable.has(sid)) return _resolutionTable.get(sid)
 
   const { services } = await api.service.list({})
-  const service = services.find(x => x.sid === sid)
-  if (!service) throw new Error(`cannot resolve ${sid}`)
+
+  const matching = services.filter(x => x.sid === sid)
+  if (matching.length == 0) throw new Error(`cannot resolve ${sid}`)
+  if (matching.length > 1) throw new Error(`multiple services resolve ${sid}`)
+  const service = matching[0]
 
   // find matching instances
   const { instances } = await api.instance.list({ serviceHash: service.hash })

--- a/src/util/resolve.ts
+++ b/src/util/resolve.ts
@@ -1,42 +1,21 @@
-import { hash, API, Instance } from "../api";
+import { hash, API } from "../api";
 
 const _resolutionTable: Map<string, hash> = new Map()
 
-// findInstanceFromService returns an instance of a service with the following strategy:
-//   - find a service that has the same hash than the serviceID
-//   - find a service that has the same sid than the serviceID (only if there is no match for the hash)
-//   - get all the instances of this service
-//   - return the instance of the service and throw an error if there is other than one instance running
-const findInstanceFromService = async (api: API, serviceID: string): Promise<Instance> => {
+// returns an instanceHash based on an sid
+// throw an error if the sid doesn't exists or have if it has more or less than one instance running
+export const resolveSID = async (api: API, sid: string): Promise<hash> => {
+  if (_resolutionTable.has(sid)) return _resolutionTable.get(sid)
+
   const { services } = await api.service.list({})
-  // Find by hash then by sid
-  const service = services.find(x => x.hash === serviceID) || services.find(x => x.sid === serviceID)
-  if (!service) throw new Error(`cannot resolve ${serviceID}`)
+  const service = services.find(x => x.sid === sid)
+  if (!service) throw new Error(`cannot resolve ${sid}`)
 
   // find matching instances
   const { instances } = await api.instance.list({ serviceHash: service.hash })
   if (!instances || instances.length === 0) throw new Error(`no instances running for the service ${service.sid}`)
   if (instances.length > 1) throw new Error(`multiple instances running for the service ${service.sid}`)
-  return instances[0]
-}
 
-// resolveInstanceHash
-// Return the instance hash based on a serviceID that can be:
-//   - instanceHash
-//   - sid
-//   - serviceHash
-// Throw an error if a serviceID has multiple instances running
-// Warning: this function is making multiple requests to the Engine so not really efficient.
-// it needs to be used carefully
-export const resolveInstanceHash = async (api: API, serviceID: string): Promise<hash> => {
-  if (_resolutionTable.has(serviceID)) return _resolutionTable.get(serviceID)
-
-  try {
-    const instance = await api.instance.get({ hash: serviceID })
-    _resolutionTable.set(serviceID, instance.hash)
-  } catch (e) {
-    const instance = await findInstanceFromService(api, serviceID)
-    _resolutionTable.set(serviceID, instance.hash)
-  }
-  return _resolutionTable.get(serviceID)
+  _resolutionTable.set(sid, instances[0].hash)
+  return _resolutionTable.get(sid)
 }

--- a/src/util/resolve_test.ts
+++ b/src/util/resolve_test.ts
@@ -37,8 +37,7 @@ test('resolve service by sid (multiple)', async function (t) {
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
   sinon.stub(api.service, 'list').callsFake(() => ({ services: [{ sid }, { sid }] }))
   try {
-    console.log(await resolveSID(api, sid))
-
+    await resolveSID(api, sid)
   } catch (e) {
     t.equal(e.message, "multiple services resolve multiplesid")
   }

--- a/src/util/resolve_test.ts
+++ b/src/util/resolve_test.ts
@@ -1,0 +1,51 @@
+import * as test from 'tape'
+import * as sinon from 'sinon'
+import { resolveInstanceHash } from './resolve'
+import Api from '../api/mock'
+
+const instances = [{ hash: 'instancehash', serviceHash: 'servicehash' }]
+const services = [{ hash: 'servicehash', sid: 'servicesid' }]
+
+test('resolve instance hash', async function (t) {
+  t.plan(1);
+  const api = Api('')
+  const hash = "instancehash"
+  sinon.stub(api.instance, 'get').callsFake(() => instances[0])
+  const res = await resolveInstanceHash(api, hash)
+  t.equal(res, hash)
+});
+
+test('resolve service invalid', async function (t) {
+  t.plan(1);
+  const api = Api('')
+  const hash = "invalid"
+  sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
+  sinon.stub(api.service, 'list').callsFake(() => ({ services }))
+  try {
+    await resolveInstanceHash(api, hash)
+  } catch (e) {
+    t.ok(e)
+  }
+});
+
+test('resolve service by hash', async function (t) {
+  t.plan(1);
+  const api = Api('')
+  const hash = "servicehash"
+  sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
+  sinon.stub(api.service, 'list').callsFake(() => ({ services }))
+  sinon.stub(api.instance, 'list').callsFake(() => ({ instances }))
+  const instanceHash = await resolveInstanceHash(api, hash)
+  t.equal(instanceHash, instances[0].hash)
+});
+
+test('resolve service by sid', async function (t) {
+  t.plan(1);
+  const api = Api('')
+  const hash = "servicesid"
+  sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
+  sinon.stub(api.service, 'list').callsFake(() => ({ services }))
+  sinon.stub(api.instance, 'list').callsFake(() => ({ instances }))
+  const instanceHash = await resolveInstanceHash(api, hash)
+  t.equal(instanceHash, instances[0].hash)
+});

--- a/src/util/resolve_test.ts
+++ b/src/util/resolve_test.ts
@@ -1,19 +1,10 @@
 import * as test from 'tape'
 import * as sinon from 'sinon'
-import { resolveInstanceHash } from './resolve'
+import { resolveSID } from './resolve'
 import Api from '../api/mock'
 
 const instances = [{ hash: 'instancehash', serviceHash: 'servicehash' }]
 const services = [{ hash: 'servicehash', sid: 'servicesid' }]
-
-test('resolve instance hash', async function (t) {
-  t.plan(1);
-  const api = Api('')
-  const hash = "instancehash"
-  sinon.stub(api.instance, 'get').callsFake(() => instances[0])
-  const res = await resolveInstanceHash(api, hash)
-  t.equal(res, hash)
-});
 
 test('resolve service invalid', async function (t) {
   t.plan(1);
@@ -22,21 +13,10 @@ test('resolve service invalid', async function (t) {
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
   sinon.stub(api.service, 'list').callsFake(() => ({ services }))
   try {
-    await resolveInstanceHash(api, hash)
+    await resolveSID(api, hash)
   } catch (e) {
     t.ok(e)
   }
-});
-
-test('resolve service by hash', async function (t) {
-  t.plan(1);
-  const api = Api('')
-  const hash = "servicehash"
-  sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
-  sinon.stub(api.service, 'list').callsFake(() => ({ services }))
-  sinon.stub(api.instance, 'list').callsFake(() => ({ instances }))
-  const instanceHash = await resolveInstanceHash(api, hash)
-  t.equal(instanceHash, instances[0].hash)
 });
 
 test('resolve service by sid', async function (t) {
@@ -46,6 +26,6 @@ test('resolve service by sid', async function (t) {
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
   sinon.stub(api.service, 'list').callsFake(() => ({ services }))
   sinon.stub(api.instance, 'list').callsFake(() => ({ instances }))
-  const instanceHash = await resolveInstanceHash(api, hash)
+  const instanceHash = await resolveSID(api, hash)
   t.equal(instanceHash, instances[0].hash)
 });

--- a/src/util/resolve_test.ts
+++ b/src/util/resolve_test.ts
@@ -9,11 +9,11 @@ const services = [{ hash: 'servicehash', sid: 'servicesid' }]
 test('resolve service invalid', async function (t) {
   t.plan(1);
   const api = Api('')
-  const hash = "invalid"
+  const sid = "invalid"
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
   sinon.stub(api.service, 'list').callsFake(() => ({ services }))
   try {
-    await resolveSID(api, hash)
+    await resolveSID(api, sid)
   } catch (e) {
     t.ok(e)
   }
@@ -22,10 +22,24 @@ test('resolve service invalid', async function (t) {
 test('resolve service by sid', async function (t) {
   t.plan(1);
   const api = Api('')
-  const hash = "servicesid"
+  const sid = "servicesid"
   sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
   sinon.stub(api.service, 'list').callsFake(() => ({ services }))
   sinon.stub(api.instance, 'list').callsFake(() => ({ instances }))
-  const instanceHash = await resolveSID(api, hash)
+  const instanceHash = await resolveSID(api, sid)
   t.equal(instanceHash, instances[0].hash)
+});
+
+test('resolve service by sid (multiple)', async function (t) {
+  t.plan(1);
+  const api = Api('')
+  const sid = "multiplesid"
+  sinon.stub(api.instance, 'get').callsFake(() => { throw new Error("not found") })
+  sinon.stub(api.service, 'list').callsFake(() => ({ services: [{ sid }, { sid }] }))
+  try {
+    console.log(await resolveSID(api, sid))
+
+  } catch (e) {
+    t.equal(e.message, "multiple services resolve multiplesid")
+  }
 });


### PR DESCRIPTION
- Possibility to resolve an instance hash based on a sid/service hash
- use resolution in the application
- introduction of the PromiseStream in order to keep listenResult and listenEvent synchrone and still have the asynchronous resolution