### PR TITLE
Support of proto structs

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ mesg.listenEvent({
   }
 })
 .on('data', (event) => {
-  console.log('an event received:', event.key, JSON.parse(event.data))
+  console.log('an event received:', event.key, mesg.decodeData(event.data))
 })
 ```
 
@@ -77,7 +77,7 @@ mesg.listenResult({
     console.error('an error has occurred:', result.error)
     return
   }
-  console.log('a result received:', JSON.parse(result.outputs))
+  console.log('a result received:', mesg.decodeData(result.outputs))
 })
 ```
 
@@ -89,7 +89,7 @@ Execute task on a service.
 const execution = await mesg.executeTask({
   instanceHash: 'TASK_INSTANCE_HASH',
   taskKey: 'TASK_KEY',
-  inputs: JSON.stringify('INPUT_DATA'),
+  inputs: mesg.encodeData({ key: 'INPUT_DATA' }),
   tags: ['ASSOCIATE_TAG'] // optional
 })
 console.log('task in progress with execution:', execution.hash)
@@ -104,14 +104,14 @@ This can be considered as a shortcut for using both `executeTask()` and `listenR
 const result = await mesg.executeTaskAndWaitResult({
   instanceHash: 'TASK_INSTANCE_HASH',
   taskKey: 'TASK_KEY',
-  inputs: JSON.stringify('INPUT_DATA'),
+  inputs: mesg.encodeData({ key: 'INPUT_DATA' }),
   tags: ['ASSOCIATE_TAG'] // optional
 })
 if (result.error) {
   console.error('an error has occurred:', result.error)
   throw new Error(result.error)
 }
-console.log('a result received:', JSON.parse(result.outputs))
+console.log('a result received:', mesg.decodeData(result.outputs))
 ```
 
 ## Resolve SID

--- a/package-lock.json
+++ b/package-lock.json
@@ -3058,6 +3058,11 @@
         }
       }
     },
+    "pb-util": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/pb-util/-/pb-util-0.1.1.tgz",
+      "integrity": "sha512-kLAjVk5moVSO5wi9JJwSbk1qK2hYYXMXFBQWWq5m2PFBym9Q7mFMWCSDgoLFJIz0m4ebrJBsAC+dfkJaA2gotw=="
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "prepublishOnly": "npm run test && npm run build",
     "test": "ts-node ./node_modules/tape/bin/tape 'src/**/*_test.ts'",
     "coverage": "rimraf ./istanbul && tsc --project tsconfig-istanbul.json && ncp ./src/protobuf/ ./istanbul/protobuf && istanbul cover -x 'istanbul/**/*_test.js' --report html ./node_modules/.bin/tape 'istanbul/**/*_test.js'",
-    "dev": "nodemon -e ts src --exec 'npm run test'"
+    "dev": "nodemon -e ts src --exec 'npm run test'",
+    "ts-node": "ts-node"
   },
   "author": "Anthony Estebe <anthony@mesg.tech>",
   "license": "ISC",
@@ -16,6 +17,7 @@
     "@grpc/proto-loader": "^0.5.1",
     "grpc": "^1.21.1",
     "js-yaml": "^3.13.1",
+    "pb-util": "^0.1.1",
     "uuid": "^3.3.2"
   },
   "devDependencies": {

--- a/src/api/mock.ts
+++ b/src/api/mock.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events'
 import { API } from './types'
 import { Stream } from '../util/grpc';
+import { encode } from '../util/encoder';
 
 const hash = 'hash'
 
@@ -29,7 +30,7 @@ export default (endpoint: string): API => ({
   },
   execution: {
     create() { return Promise.resolve({ hash }) },
-    get() { return Promise.resolve({ parentHash: hash, eventHash: 'xxx', status: 0, instanceHash: hash, taskKey: 'xxx', inputs: '{}' }) },
+    get() { return Promise.resolve({ parentHash: hash, eventHash: 'xxx', status: 0, instanceHash: hash, taskKey: 'xxx', inputs: encode({}) }) },
     stream() { return streams.execution },
     update() { return Promise.resolve({}) }
   },

--- a/src/api/typedef/event.d.ts
+++ b/src/api/typedef/event.d.ts
@@ -20,7 +20,7 @@ declare namespace mesg {
             key?: (string|null);
 
             /** Event data */
-            data?: (string|null);
+            data?: (google.protobuf.IStruct|null);
         }
 
         /** Represents an Event. */
@@ -42,7 +42,113 @@ declare namespace mesg {
             public key: string;
 
             /** Event data. */
-            public data: string;
+            public data?: (google.protobuf.IStruct|null);
+        }
+    }
+
+    /** Namespace google. */
+    namespace google {
+
+        /** Namespace protobuf. */
+        namespace protobuf {
+
+            /** Properties of a Struct. */
+            interface IStruct {
+
+                /** Struct fields */
+                fields?: ({ [k: string]: google.protobuf.IValue }|null);
+            }
+
+            /** Represents a Struct. */
+            class Struct implements IStruct {
+
+                /**
+                 * Constructs a new Struct.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.IStruct);
+
+                /** Struct fields. */
+                public fields: { [k: string]: google.protobuf.IValue };
+            }
+
+            /** Properties of a Value. */
+            interface IValue {
+
+                /** Value nullValue */
+                nullValue?: (google.protobuf.NullValue|null);
+
+                /** Value numberValue */
+                numberValue?: (number|null);
+
+                /** Value stringValue */
+                stringValue?: (string|null);
+
+                /** Value boolValue */
+                boolValue?: (boolean|null);
+
+                /** Value structValue */
+                structValue?: (google.protobuf.IStruct|null);
+
+                /** Value listValue */
+                listValue?: (google.protobuf.IListValue|null);
+            }
+
+            /** Represents a Value. */
+            class Value implements IValue {
+
+                /**
+                 * Constructs a new Value.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.IValue);
+
+                /** Value nullValue. */
+                public nullValue: google.protobuf.NullValue;
+
+                /** Value numberValue. */
+                public numberValue: number;
+
+                /** Value stringValue. */
+                public stringValue: string;
+
+                /** Value boolValue. */
+                public boolValue: boolean;
+
+                /** Value structValue. */
+                public structValue?: (google.protobuf.IStruct|null);
+
+                /** Value listValue. */
+                public listValue?: (google.protobuf.IListValue|null);
+
+                /** Value kind. */
+                public kind?: ("nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue");
+            }
+
+            /** NullValue enum. */
+            enum NullValue {
+                NULL_VALUE = 0
+            }
+
+            /** Properties of a ListValue. */
+            interface IListValue {
+
+                /** ListValue values */
+                values?: (google.protobuf.IValue[]|null);
+            }
+
+            /** Represents a ListValue. */
+            class ListValue implements IListValue {
+
+                /**
+                 * Constructs a new ListValue.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.IListValue);
+
+                /** ListValue values. */
+                public values: google.protobuf.IValue[];
+            }
         }
     }
 
@@ -171,7 +277,7 @@ declare namespace mesg {
             key?: (string|null);
 
             /** CreateEventRequest data */
-            data?: (string|null);
+            data?: (google.protobuf.IStruct|null);
         }
 
         /** Represents a CreateEventRequest. */
@@ -190,7 +296,7 @@ declare namespace mesg {
             public key: string;
 
             /** CreateEventRequest data. */
-            public data: string;
+            public data?: (google.protobuf.IStruct|null);
         }
 
         /** Properties of a CreateEventResponse. */

--- a/src/api/typedef/execution.d.ts
+++ b/src/api/typedef/execution.d.ts
@@ -38,10 +38,10 @@ declare namespace mesg {
             taskKey?: (string|null);
 
             /** Execution inputs */
-            inputs?: (string|null);
+            inputs?: (google.protobuf.IStruct|null);
 
             /** Execution outputs */
-            outputs?: (string|null);
+            outputs?: (google.protobuf.IStruct|null);
 
             /** Execution error */
             error?: (string|null);
@@ -78,16 +78,122 @@ declare namespace mesg {
             public taskKey: string;
 
             /** Execution inputs. */
-            public inputs: string;
+            public inputs?: (google.protobuf.IStruct|null);
 
             /** Execution outputs. */
-            public outputs: string;
+            public outputs?: (google.protobuf.IStruct|null);
 
             /** Execution error. */
             public error: string;
 
             /** Execution tags. */
             public tags: string[];
+        }
+    }
+
+    /** Namespace google. */
+    namespace google {
+
+        /** Namespace protobuf. */
+        namespace protobuf {
+
+            /** Properties of a Struct. */
+            interface IStruct {
+
+                /** Struct fields */
+                fields?: ({ [k: string]: google.protobuf.IValue }|null);
+            }
+
+            /** Represents a Struct. */
+            class Struct implements IStruct {
+
+                /**
+                 * Constructs a new Struct.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.IStruct);
+
+                /** Struct fields. */
+                public fields: { [k: string]: google.protobuf.IValue };
+            }
+
+            /** Properties of a Value. */
+            interface IValue {
+
+                /** Value nullValue */
+                nullValue?: (google.protobuf.NullValue|null);
+
+                /** Value numberValue */
+                numberValue?: (number|null);
+
+                /** Value stringValue */
+                stringValue?: (string|null);
+
+                /** Value boolValue */
+                boolValue?: (boolean|null);
+
+                /** Value structValue */
+                structValue?: (google.protobuf.IStruct|null);
+
+                /** Value listValue */
+                listValue?: (google.protobuf.IListValue|null);
+            }
+
+            /** Represents a Value. */
+            class Value implements IValue {
+
+                /**
+                 * Constructs a new Value.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.IValue);
+
+                /** Value nullValue. */
+                public nullValue: google.protobuf.NullValue;
+
+                /** Value numberValue. */
+                public numberValue: number;
+
+                /** Value stringValue. */
+                public stringValue: string;
+
+                /** Value boolValue. */
+                public boolValue: boolean;
+
+                /** Value structValue. */
+                public structValue?: (google.protobuf.IStruct|null);
+
+                /** Value listValue. */
+                public listValue?: (google.protobuf.IListValue|null);
+
+                /** Value kind. */
+                public kind?: ("nullValue"|"numberValue"|"stringValue"|"boolValue"|"structValue"|"listValue");
+            }
+
+            /** NullValue enum. */
+            enum NullValue {
+                NULL_VALUE = 0
+            }
+
+            /** Properties of a ListValue. */
+            interface IListValue {
+
+                /** ListValue values */
+                values?: (google.protobuf.IValue[]|null);
+            }
+
+            /** Represents a ListValue. */
+            class ListValue implements IListValue {
+
+                /**
+                 * Constructs a new ListValue.
+                 * @param [properties] Properties to set
+                 */
+                constructor(properties?: google.protobuf.IListValue);
+
+                /** ListValue values. */
+                public values: google.protobuf.IValue[];
+            }
         }
     }
 
@@ -203,7 +309,7 @@ declare namespace mesg {
             taskKey?: (string|null);
 
             /** CreateExecutionRequest inputs */
-            inputs?: (string|null);
+            inputs?: (google.protobuf.IStruct|null);
 
             /** CreateExecutionRequest tags */
             tags?: (string[]|null);
@@ -225,7 +331,7 @@ declare namespace mesg {
             public taskKey: string;
 
             /** CreateExecutionRequest inputs. */
-            public inputs: string;
+            public inputs?: (google.protobuf.IStruct|null);
 
             /** CreateExecutionRequest tags. */
             public tags: string[];
@@ -339,7 +445,7 @@ declare namespace mesg {
             hash?: (string|null);
 
             /** UpdateExecutionRequest outputs */
-            outputs?: (string|null);
+            outputs?: (google.protobuf.IStruct|null);
 
             /** UpdateExecutionRequest error */
             error?: (string|null);
@@ -358,7 +464,7 @@ declare namespace mesg {
             public hash: string;
 
             /** UpdateExecutionRequest outputs. */
-            public outputs: string;
+            public outputs?: (google.protobuf.IStruct|null);
 
             /** UpdateExecutionRequest error. */
             public error: string;

--- a/src/application/application.ts
+++ b/src/application/application.ts
@@ -1,4 +1,6 @@
 import * as uuidv4 from 'uuid/v4'
+import { google } from "../api/typedef/execution";
+import { decode, encode } from '../util/encoder'
 import { checkStreamReady, errNoStatus, Stream } from '../util/grpc';
 import { API, ExecutionCreateInputs, ExecutionCreateOutputs, EventStreamInputs, Event, ExecutionStreamInputs, Execution, ExecutionStatus } from '../api';
 import { resolveSID } from '../util/resolve';
@@ -13,6 +15,14 @@ class Application {
 
   constructor(api: API) {
     this.api = api;
+  }
+
+  decodeData(data: google.protobuf.IStruct) {
+    return decode(data)
+  }
+
+  encodeData(data: { [key: string]: any }) {
+    return encode(data)
   }
 
   resolve(sid: string): Promise<string> {

--- a/src/protobuf/api/event.proto
+++ b/src/protobuf/api/event.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
 import "protobuf/types/event.proto";
 
 package api;
@@ -45,7 +46,7 @@ message CreateEventRequest {
   string key = 2;
 
   // data is the data for the event.
-  string data = 3;
+  google.protobuf.Struct data = 3;
 }
 
 // CreateEventResponse defines response for execution update.

--- a/src/protobuf/api/execution.proto
+++ b/src/protobuf/api/execution.proto
@@ -1,5 +1,6 @@
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
 import "protobuf/types/execution.proto";
 
 package api;
@@ -29,7 +30,7 @@ service Execution {
 message CreateExecutionRequest {
   string instanceHash = 1;
   string taskKey = 2;
-  string inputs = 3;
+  google.protobuf.Struct inputs = 3;
   repeated string tags = 4;
 }
 
@@ -74,7 +75,7 @@ message UpdateExecutionRequest {
   // result pass to execution
   oneof result {
     // outputs is a success result.
-    string outputs = 2;
+    google.protobuf.Struct outputs = 2;
 
     // error is an error result.
     string error = 3;

--- a/src/protobuf/types/event.proto
+++ b/src/protobuf/types/event.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
+
 package types;
 option go_package = "github.com/mesg-foundation/engine/protobuf/types";
 
@@ -15,5 +17,5 @@ message Event {
   string key = 3;
 
   // data is the data for the event.
-  string data = 4;
+  google.protobuf.Struct data = 4;
 }

--- a/src/protobuf/types/execution.proto
+++ b/src/protobuf/types/execution.proto
@@ -1,5 +1,7 @@
 syntax = "proto3";
 
+import "google/protobuf/struct.proto";
+
 package types;
 option go_package = "github.com/mesg-foundation/engine/protobuf/types";
 
@@ -44,10 +46,10 @@ message Execution {
   string taskKey = 6;
 
   // inputs data of the execution.
-  string inputs = 7;
+  google.protobuf.Struct inputs = 7;
 
   // outputs are the returned data of successful execution.
-  string outputs = 8;
+  google.protobuf.Struct outputs = 8;
 
   // error message of a failed execution.
   string error = 9;

--- a/src/service/service_test.ts
+++ b/src/service/service_test.ts
@@ -2,6 +2,7 @@ import * as test from 'tape'
 import * as sinon from 'sinon'
 import Service from './service'
 import Api, { API } from '../api/mock'
+import { encode } from '../util/encoder';
 
 const token = "token"
 
@@ -92,12 +93,12 @@ test('listenTask() should handle tasks and submit result', async function (t) {
       return outputs
     }
   });
-  t.doesNotThrow(() => stream.emit('data', { hash, taskKey: 'task1', inputs: JSON.stringify(inputs) }));
+  t.doesNotThrow(() => stream.emit('data', { hash, taskKey: 'task1', inputs: encode(inputs) }));
   await setTimeout(() => { }, 0)
   const args = spy.getCall(0).args[0];
   spy.restore();
   t.equal(args.hash, hash);
-  t.equal(args.outputs, JSON.stringify(outputs));
+  t.equal(JSON.stringify(args.outputs), JSON.stringify(encode(outputs)));
 });
 
 test('emitEvent() should emit an event', function (t) {
@@ -111,7 +112,7 @@ test('emitEvent() should emit an event', function (t) {
   const args = spy.getCall(0).args[0];
   t.equal(args.instanceHash, token);
   t.equal(args.key, key);
-  t.equal(args.data, JSON.stringify(data));
+  t.equal(JSON.stringify(args.data), JSON.stringify(encode(data)));
   spy.restore();
 });
 

--- a/src/util/encoder.ts
+++ b/src/util/encoder.ts
@@ -12,7 +12,7 @@ const encodeField = (data, key) => {
       }}
     case '[object Array]':
       return { listValue: {
-        values: encodeFields(value)
+        values: value.map((_, i) => encodeField(value, i))
       }}
     case '[object Number]':
       return { numberValue: value }
@@ -27,7 +27,7 @@ const encodeField = (data, key) => {
   }
 }
 
-const encodeFields = data => Object.keys(data).reduce((prev, next) => ({
+const encodeFields = data => Object.keys(data || {}).reduce((prev, next) => ({
   ...prev,
   [next]: encodeField(data, next)
 }), {})
@@ -51,14 +51,14 @@ const decodeField = (field: google.protobuf.IValue) => {
     case 'struct':
       return decode(value)
     case 'list':
-      return Object.keys(value.values).map(x => decodeField(value.values[x]))
+      return value.values.map((_, i) => decodeField(value.values[i]))
     default:
       throw new Error('not implemented')
   }
 }
 
 export const decode = (data: google.protobuf.IStruct): { [key: string]: any } => {
-  return Object.keys(data.fields).reduce((prev, next) => ({
+  return Object.keys(data.fields || {}).reduce((prev, next) => ({
     ...prev,
     [next]: decodeField(data.fields[next])
   }), {})

--- a/src/util/encoder.ts
+++ b/src/util/encoder.ts
@@ -1,0 +1,65 @@
+import { google } from "../api/typedef/execution";
+
+const encodeField = (data, key) => {
+  const value = data[key]
+  switch (Object.prototype.toString.call(value)) {
+    case '[object Null]':
+    case '[object Undefined]':
+      return { nullValue: value }
+    case '[object Object]':
+      return { structValue: {
+        fields: encodeFields(value)
+      }}
+    case '[object Array]':
+      return { listValue: {
+        values: encodeFields(value)
+      }}
+    case '[object Number]':
+      return { numberValue: value }
+    case '[object Boolean]':
+      return { boolValue: value }
+    case '[object String]':
+      return { stringValue: value }
+    case '[object Date]':
+      return { stringValue: (value as Date).toJSON() }
+    default:
+      throw new Error('not supported')
+  }
+}
+
+const encodeFields = data => Object.keys(data).reduce((prev, next) => ({
+  ...prev,
+  [next]: encodeField(data, next)
+}), {})
+
+export const encode = (data: { [key: string]: any }): google.protobuf.IStruct => {
+  return {
+    fields: encodeFields(data)
+  }
+}
+
+const decodeField = (field: google.protobuf.IValue) => {
+  const kind = ['list', 'struct', 'string', 'number', 'bool']
+    .find(x => field[`${x}Value`] !== undefined) || 'null'
+  const value = field[`${kind}Value`]
+  switch (kind) {
+    case 'string':
+    case 'number':
+    case 'bool':
+    case 'null':
+      return value
+    case 'struct':
+      return decode(value)
+    case 'list':
+      return Object.keys(value.values).map(x => decodeField(value.values[x]))
+    default:
+      throw new Error('not implemented')
+  }
+}
+
+export const decode = (data: google.protobuf.IStruct): { [key: string]: any } => {
+  return Object.keys(data.fields).reduce((prev, next) => ({
+    ...prev,
+    [next]: decodeField(data.fields[next])
+  }), {})
+}

--- a/src/util/encoder_test.ts
+++ b/src/util/encoder_test.ts
@@ -1,0 +1,27 @@
+import * as test from 'tape'
+import { encode, decode } from './encoder'
+
+test('encode/decode', function (t) {
+  t.plan(1);
+  const date = new Date()
+  const data = {
+    number: 1,
+    string: 'hello',
+    boolean_false: false,
+    boolean_true: true,
+    null: null,
+    undefined: undefined,
+    array: [1, 2, 3],
+    array_struct: [{ number: 2, string: '2' }],
+    date: date,
+    object: {
+      number: 3,
+      string: '3'
+    }
+  }
+  const res = decode(encode(data))
+  t.deepEqual(res, {
+    ...data,
+    date: date.toJSON()
+  })
+});


### PR DESCRIPTION
Add support of `Struct` in the grpc API.

This change **doesn't impact the Services** but it **impacts Applications**.

Before:

```js
mesg.executeTask({
  instanceHash: 'xxx',
  taskKey: 'xxx',
  inputs: JSON.stringify({})
})
```

After:
```js
mesg.executeTask({
  instanceHash: 'xxx',
  taskKey: 'xxx',
  inputs: mesg.encodeData({})
})
```

Same when we listen an event or an execution we need to use the `mesg.decodeData` instead of `JSON.parse`