### PR TITLE
Add credential system

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,3 +1,4 @@
+import { Metadata } from 'grpc'
 import { createClient } from '../util/grpc'
 import {
   API,
@@ -7,10 +8,18 @@ import {
   InstanceCreateInputs, InstanceGetInputs, InstanceListInputs, InstanceDeleteInputs, InstanceCreateOutputs, InstanceGetOutputs, InstanceListOutputs, InstanceDeleteOutputs,
   ServiceCreateInputs, ServiceGetInputs, ServiceListInputs, ServiceDeleteInputs, ServiceCreateOutputs, ServiceGetOutputs, ServiceListOutputs, ServiceDeleteOutputs,
   ProcessCreateInputs, ProcessGetInputs, ProcessListInputs, ProcessDeleteInputs, ProcessCreateOutputs, ProcessGetOutputs, ProcessListOutputs, ProcessDeleteOutputs,
-  InfoOutputs
+  InfoOutputs,
+  Credential
 } from './types'
 
-const promisify = (client, method) => request => new Promise((resolve, reject) => client[method](request, (err, res) => err ? reject(err) : resolve(res)))
+const promisify = (client, method) => (request, credential?: Credential) => {
+  const metadata = new Metadata()
+  if (credential) {
+    metadata.set('credential_username', credential.username)
+    metadata.set('credential_passphrase', credential.passphrase)
+  }
+  return new Promise((resolve, reject) => client[method](request, metadata, (err, res) => err ? reject(err) : resolve(res)))
+}
 
 export default (endpoint: string): API => {
   const account = createClient('Account', 'protobuf/api/account.proto', endpoint)
@@ -22,38 +31,38 @@ export default (endpoint: string): API => {
   const core = createClient('Core', 'protobuf/api/core.proto', endpoint)
   return {
     account: {
-      get: promisify(account, 'Get') as (request: AccountGetInputs) => AccountGetOutputs,
-      list: promisify(account, 'List') as (request: AccountListInputs) => AccountListOutputs,
-      create: promisify(account, 'Create') as (request: AccountCreateInputs) => AccountCreateOutputs,
-      delete: promisify(account, 'Delete') as (request: AccountDeleteInputs) => AccountDeleteOutputs
+      get: promisify(account, 'Get') as (request: AccountGetInputs, credential?: Credential) => AccountGetOutputs,
+      list: promisify(account, 'List') as (request: AccountListInputs, credential?: Credential) => AccountListOutputs,
+      create: promisify(account, 'Create') as (request: AccountCreateInputs, credential?: Credential) => AccountCreateOutputs,
+      delete: promisify(account, 'Delete') as (request: AccountDeleteInputs, credential?: Credential) => AccountDeleteOutputs
     },
     event: {
-      create: promisify(event, 'Create') as (request: EventCreateInputs) => EventCreateOutputs,
-      stream: (request: EventStreamInputs) => event.Stream(request)
+      create: promisify(event, 'Create') as (request: EventCreateInputs, credential?: Credential) => EventCreateOutputs,
+      stream: (request: EventStreamInputs, credential?: Credential) => event.Stream(request)
     },
     execution: {
-      create: promisify(execution, 'Create') as (request: ExecutionCreateInputs) => ExecutionCreateOutputs,
-      get: promisify(execution, 'Get') as (request: ExecutionGetInputs) => ExecutionGetOutputs,
-      update: promisify(execution, 'Update') as (request: ExecutionUpdateInputs) => ExecutionUpdateOutputs,
-      stream: (request: ExecutionStreamInputs) => execution.Stream(request)
+      create: promisify(execution, 'Create') as (request: ExecutionCreateInputs, credential?: Credential) => ExecutionCreateOutputs,
+      get: promisify(execution, 'Get') as (request: ExecutionGetInputs, credential?: Credential) => ExecutionGetOutputs,
+      update: promisify(execution, 'Update') as (request: ExecutionUpdateInputs, credential?: Credential) => ExecutionUpdateOutputs,
+      stream: (request: ExecutionStreamInputs, credential?: Credential) => execution.Stream(request)
     },
     instance: {
-      create: promisify(instance, 'Create') as (request: InstanceCreateInputs) => InstanceCreateOutputs,
-      get: promisify(instance, 'Get') as (request: InstanceGetInputs) => InstanceGetOutputs,
-      list: promisify(instance, 'List') as (request: InstanceListInputs) => InstanceListOutputs,
-      delete: promisify(instance, 'Delete') as (request: InstanceDeleteInputs) => InstanceDeleteOutputs
+      create: promisify(instance, 'Create') as (request: InstanceCreateInputs, credential?: Credential) => InstanceCreateOutputs,
+      get: promisify(instance, 'Get') as (request: InstanceGetInputs, credential?: Credential) => InstanceGetOutputs,
+      list: promisify(instance, 'List') as (request: InstanceListInputs, credential?: Credential) => InstanceListOutputs,
+      delete: promisify(instance, 'Delete') as (request: InstanceDeleteInputs, credential?: Credential) => InstanceDeleteOutputs
     },
     service: {
-      create: promisify(service, 'Create') as (request: ServiceCreateInputs) => ServiceCreateOutputs,
-      get: promisify(service, 'Get') as (request: ServiceGetInputs) => ServiceGetOutputs,
-      list: promisify(service, 'List') as (request: ServiceListInputs) => ServiceListOutputs,
-      delete: promisify(service, 'Delete') as (request: ServiceDeleteInputs) => ServiceDeleteOutputs
+      create: promisify(service, 'Create') as (request: ServiceCreateInputs, credential?: Credential) => ServiceCreateOutputs,
+      get: promisify(service, 'Get') as (request: ServiceGetInputs, credential?: Credential) => ServiceGetOutputs,
+      list: promisify(service, 'List') as (request: ServiceListInputs, credential?: Credential) => ServiceListOutputs,
+      delete: promisify(service, 'Delete') as (request: ServiceDeleteInputs, credential?: Credential) => ServiceDeleteOutputs
     },
     process: {
-      create: promisify(process, 'Create') as (request: ProcessCreateInputs) => ProcessCreateOutputs,
-      get: promisify(process, 'Get') as (request: ProcessGetInputs) => ProcessGetOutputs,
-      list: promisify(process, 'List') as (request: ProcessListInputs) => ProcessListOutputs,
-      delete: promisify(process, 'Delete') as (request: ProcessDeleteInputs) => ProcessDeleteOutputs
+      create: promisify(process, 'Create') as (request: ProcessCreateInputs, credential?: Credential) => ProcessCreateOutputs,
+      get: promisify(process, 'Get') as (request: ProcessGetInputs, credential?: Credential) => ProcessGetOutputs,
+      list: promisify(process, 'List') as (request: ProcessListInputs, credential?: Credential) => ProcessListOutputs,
+      delete: promisify(process, 'Delete') as (request: ProcessDeleteInputs, credential?: Credential) => ProcessDeleteOutputs
     },
     core: {
       info: promisify(core, 'Info') as () => InfoOutputs

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -16,6 +16,10 @@ export const ExecutionStatus = {
   FAILED: 4
 }
 
+export type Credential = {
+  username: string
+  passphrase: string
+}
 
 export type Account = AccountType.mesg.types.IAccount
 
@@ -99,38 +103,38 @@ export type InfoOutputs = Promise<{ version: string, services: { sid: string, ha
 
 export type API = {
   account: {
-    get: (request: AccountGetInputs) => AccountGetOutputs
-    list: (request: AccountListInputs) => AccountListOutputs
-    create: (request: AccountCreateInputs) => AccountCreateOutputs
-    delete: (request: AccountDeleteInputs) => AccountDeleteOutputs
+    get: (request: AccountGetInputs, credential?: Credential) => AccountGetOutputs
+    list: (request: AccountListInputs, credential?: Credential) => AccountListOutputs
+    create: (request: AccountCreateInputs, credential?: Credential) => AccountCreateOutputs
+    delete: (request: AccountDeleteInputs, credential?: Credential) => AccountDeleteOutputs
   },
   event: {
-    create: (request: EventCreateInputs) => EventCreateOutputs
-    stream: (request: EventStreamInputs) => EventStreamOutputs
+    create: (request: EventCreateInputs, credential?: Credential) => EventCreateOutputs
+    stream: (request: EventStreamInputs, credential?: Credential) => EventStreamOutputs
   }
   execution: {
-    get: (request: ExecutionGetInputs) => ExecutionGetOutputs
-    stream: (request: ExecutionStreamInputs) => ExecutionStreamOutputs
-    create: (request: ExecutionCreateInputs) => ExecutionCreateOutputs
-    update: (request: ExecutionUpdateInputs) => ExecutionUpdateOutputs
+    get: (request: ExecutionGetInputs, credential?: Credential) => ExecutionGetOutputs
+    stream: (request: ExecutionStreamInputs, credential?: Credential) => ExecutionStreamOutputs
+    create: (request: ExecutionCreateInputs, credential?: Credential) => ExecutionCreateOutputs
+    update: (request: ExecutionUpdateInputs, credential?: Credential) => ExecutionUpdateOutputs
   }
   instance: {
-    get: (request: InstanceGetInputs) => InstanceGetOutputs
-    list: (request: InstanceListInputs) => InstanceListOutputs
-    create: (request: InstanceCreateInputs) => InstanceCreateOutputs
-    delete: (request: InstanceDeleteInputs) => InstanceDeleteOutputs
+    get: (request: InstanceGetInputs, credential?: Credential) => InstanceGetOutputs
+    list: (request: InstanceListInputs, credential?: Credential) => InstanceListOutputs
+    create: (request: InstanceCreateInputs, credential?: Credential) => InstanceCreateOutputs
+    delete: (request: InstanceDeleteInputs, credential?: Credential) => InstanceDeleteOutputs
   }
   service: {
-    get: (request: ServiceGetInputs) => ServiceGetOutputs
-    list: (request: ServiceListInputs) => ServiceListOutputs
-    create: (request: ServiceCreateInputs) => ServiceCreateOutputs
-    delete: (request: ServiceDeleteInputs) => ServiceDeleteOutputs
+    get: (request: ServiceGetInputs, credential?: Credential) => ServiceGetOutputs
+    list: (request: ServiceListInputs, credential?: Credential) => ServiceListOutputs
+    create: (request: ServiceCreateInputs, credential?: Credential) => ServiceCreateOutputs
+    delete: (request: ServiceDeleteInputs, credential?: Credential) => ServiceDeleteOutputs
   },
   process: {
-    get: (request: ProcessGetInputs) => ProcessGetOutputs
-    list: (request: ProcessListInputs) => ProcessListOutputs
-    create: (request: ProcessCreateInputs) => ProcessCreateOutputs
-    delete: (request: ProcessDeleteInputs) => ProcessDeleteOutputs
+    get: (request: ProcessGetInputs, credential?: Credential) => ProcessGetOutputs
+    list: (request: ProcessListInputs, credential?: Credential) => ProcessListOutputs
+    create: (request: ProcessCreateInputs, credential?: Credential) => ProcessCreateOutputs
+    delete: (request: ProcessDeleteInputs, credential?: Credential) => ProcessDeleteOutputs
   },
   core: {
     info: () => InfoOutputs


### PR DESCRIPTION
Add (optional) credential system to all gRPC api.
The credential object is converted to gRPC metadata.

Works with https://github.com/mesg-foundation/engine/pull/1355.
Closes https://github.com/mesg-foundation/mesg-js/issues/138